### PR TITLE
Adds Error on no-args

### DIFF
--- a/mew
+++ b/mew
@@ -4,6 +4,9 @@ import sys
 import os
 from MEW import MEW
 
+if len(sys.argv) < 2:
+	sys.exit("Error : No Arguments specified")
+
 packageManager = sys.argv[1]
 commands = []
 arguments = []


### PR DESCRIPTION
Fixes : https://github.com/fossasia/mew/issues/19
Displays an error when no arguments are passed through commandline.
